### PR TITLE
Workaround by using new system image to precompile Revise

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ RUN apt-get update -y && \
     apt-get install -y ssh curl wget build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget -nv https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.0-beta3-linux-x86_64.tar.gz
-RUN tar xf julia-1.9.0-beta3-linux-x86_64.tar.gz
-RUN rm julia-1.9.0-beta3-linux-x86_64.tar.gz
-RUN ln -s /julia-1.9.0-beta3/bin/julia /usr/local/bin/julia
+RUN wget -nv https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.0-beta4-linux-x86_64.tar.gz
+RUN tar xf julia-1.9.0-beta4-linux-x86_64.tar.gz
+RUN rm julia-1.9.0-beta4-linux-x86_64.tar.gz
+RUN ln -s /julia-1.9.0-beta4/bin/julia /usr/local/bin/julia
 RUN mkdir -p ~/.julia/config
 
 COPY src src

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ COPY Project.toml Project.toml
 COPY Manifest.toml Manifest.toml
 
 RUN julia --project=sysimage -e 'import Pkg; Pkg.build(); include(joinpath("sysimage", "build_sysimage.jl")); build()'
-RUN julia -e 'import Pkg; Pkg.add("Revise")'
+RUN julia -J sysimage/sysimage.so -e 'import Pkg; Pkg.add("Revise")'
 RUN julia --project -J sysimage/sysimage.so -e 'using Revise'


### PR DESCRIPTION
This shouldn't be necessary, Revise should be recompiled when loading with the new system image, but as a workaround, it does allow you to load `Revise`.